### PR TITLE
Eslint Error message

### DIFF
--- a/src/lint/linter/ArcanistESLintLinter.php
+++ b/src/lint/linter/ArcanistESLintLinter.php
@@ -117,9 +117,15 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
             $results = idx(idx($json, 'results')[0], 'messages');
         } catch (PhutilJSONParserException $ex) {
             // Something went wrong and we can't decode the output. Exit abnormally.
-            throw new PhutilProxyException(
-                pht('ESLint returned unparseable output.'),
-                $ex);
+            if (empty($stdout)) {
+              throw new PhutilProxyException(
+                  pht('ESLint threw an error: '.$stderr),
+                  $ex);
+            } else {
+              throw new PhutilProxyException(
+                  pht('ESLint returned unparseable output: '.$stdout),
+                  $ex);
+            }
         }
         $messages = array();
         foreach ($results as $result) {


### PR DESCRIPTION
@turadg @jnwng ptal

cc @zhaojunz 

This will output the error from eslint.

```
$ arc lint static/bundles/page/components/PageHeader.jsx
Exception
Some linters failed:
    - PhutilProxyException: ESLint threw an error: /usr/local/lib/node_modules/eslint/lib/config.js:141
                          throw e;
                                ^
      Error: Cannot find module 'eslint-config-airbnb'
      Referenced from: /Users/yang/base/coursera/web/.eslintrc
          at Function.Module._resolveFilename (module.js:336:15)
          at Function.Module._load (module.js:278:25)
          at Module.require (module.js:365:17)
          at require (module.js:384:17)
          at loadConfig (/usr/local/lib/node_modules/eslint/lib/config.js:104:48)
          at /usr/local/lib/node_modules/eslint/lib/config.js:135:46
          at Array.reduceRight (native)
          at loadConfig (/usr/local/lib/node_modules/eslint/lib/config.js:119:36)
          at new Config (/usr/local/lib/node_modules/eslint/lib/config.js:343:34)
          at CLIEngine.executeOnFiles (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:377:28)

(Run with `--trace` for a full exception trace.)
49
```