### PR TITLE
Stop adding misleading documentation messages to non core eslint rules

### DIFF
--- a/src/lint/linter/ArcanistESLintLinter.php
+++ b/src/lint/linter/ArcanistESLintLinter.php
@@ -15,7 +15,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     }
 
     public function getRuleDocumentationURI($ruleId) {
-        return $this->getInfoURI().'/docs/rules/'.$ruleId;
+      return $this->getInfoURI().'/docs/rules/'.$ruleId;
     }
 
     public function getInfoDescription() {
@@ -147,7 +147,15 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
         $messages = array();
         foreach ($results as $result) {
             $ruleId = idx($result, 'ruleId');
-            $description = idx($result, 'message')."\r\nSee documentation at ".$this->getRuleDocumentationURI($ruleId);
+
+            // Only rules built into eslint are guaranteed to have a rule documentation URI.
+            if (strpos($ruleId, '/') !== FALSE) {
+              $documentation = '';
+            } else {
+              $documentation = "\r\nSee documentation at ".$this->getRuleDocumentationURI($ruleId);
+            }
+
+            $description = idx($result, 'message').$documentation;
             $message = new ArcanistLintMessage();
             $message->setChar(idx($result, 'column'));
             $message->setCode($ruleId);

--- a/src/lint/linter/ArcanistESLintLinter.php
+++ b/src/lint/linter/ArcanistESLintLinter.php
@@ -15,7 +15,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     }
 
     public function getRuleDocumentationURI($ruleId) {
-      return $this->getInfoURI().'/docs/rules/'.$ruleId;
+        return $this->getInfoURI().'/docs/rules/'.$ruleId;
     }
 
     public function getInfoDescription() {


### PR DESCRIPTION
Rules from plugins generally have a rule namespace and a rule id.

```
react/jsx-no-bind
```

Documentation for that does not exist at www.eslint.org/docs/rules/react/jsx-no-bind yet we've been linking to it.