### PR TITLE
Remove specifying eslint env/config/ignore

### DIFF
--- a/src/lint/linter/ArcanistESLintLinter.php
+++ b/src/lint/linter/ArcanistESLintLinter.php
@@ -53,37 +53,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
 
         $options[] = '--format='.dirname(realpath(__FILE__)).'/eslintJsonFormat.js';
 
-        if ($this->eslintenv) {
-            $options[] = '--env='.$this->eslintenv;
-        }
-
-        if ($this->eslintconfig) {
-            $options[] = '--config='.$this->eslintconfig;
-        }
-
-        if ($this->eslintignore) {
-            $options[] = '--ignore-path='.$this->eslintignore;
-        }
-
         return $options;
-    }
-
-    public function getLinterConfigurationOptions() {
-        $options = array(
-            'eslint.eslintenv' => array(
-                'type' => 'optional string',
-                'help' => pht('enables specific environments.'),
-            ),
-            'eslint.eslintconfig' => array(
-                'type' => 'optional string',
-                'help' => pht('config file to use. the default is .eslint.'),
-            ),
-            'eslint.eslintignore' => array(
-                'type' => 'optional string',
-                'help' => pht('ignre file to use. the default is .eslintignore.'),
-            ),
-        );
-        return $options + parent::getLinterConfigurationOptions();
     }
 
     public function getLintSeverityMap() {
@@ -91,23 +61,6 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
             2 => ArcanistLintSeverity::SEVERITY_ERROR,
             1 => ArcanistLintSeverity::SEVERITY_WARNING
         );
-    }
-
-    public function setLinterConfigurationValue($key, $value) {
-
-        switch ($key) {
-            case 'eslint.eslintenv':
-                $this->eslintenv = $value;
-                return;
-            case 'eslint.eslintconfig':
-                $this->eslintconfig = $value;
-                return;
-            case 'eslint.eslintignore':
-                $this->eslintignore = $value;
-                return;
-        }
-
-        return parent::setLinterConfigurationValue($key, $value);
     }
 
     protected function getDefaultMessageSeverity($code) {


### PR DESCRIPTION
ESLint knows how to pick up the closest .eslintrc config to each linted file.
Passing this in manually in arcanist only limits us.

This let's Arcanist pick up nested .eslintrc configurations. Will be landed with code changes here: https://phabricator.dkandu.me/D42901

nested .eslintrc.js
<img width="549" alt="image" src="https://cloud.githubusercontent.com/assets/588210/18500358/a9d0fef6-79fb-11e6-98c1-5e1f1c5d3341.png">

contents of nested .eslintrc.js, notice the extends
<img width="517" alt="image" src="https://cloud.githubusercontent.com/assets/588210/18500365/b08c183e-79fb-11e6-9893-a5f3c010bc7d.png">

works fine with both eslint and arcanist
<img width="959" alt="image" src="https://cloud.githubusercontent.com/assets/588210/18500355/a3f27faa-79fb-11e6-97f6-573a40956696.png">

cc @jnwng @mustafa-coursera 