### PR TITLE
Enable `scalafmt` linter autofix

### DIFF
--- a/src/lint/linter/ArcanistScalafmtLinter.php
+++ b/src/lint/linter/ArcanistScalafmtLinter.php
@@ -56,9 +56,13 @@ final class ArcanistScalafmtLinter extends ArcanistExternalLinter {
           ->setChar(1)
           ->setSeverity(ArcanistLintSeverity::SEVERITY_AUTOFIX)
           ->setName($this->getLinterName())
-          ->setDescription('File needs to be reformatted with scalafmt')
           ->setOriginalText($originalText)
-          ->setReplacementText($replacementText)
+          ->setReplacementText($replacementText),
+        id(new ArcanistLintMessage())
+          ->setPath($path)
+          ->setSeverity(ArcanistLintSeverity::SEVERITY_ERROR)
+          ->setName($this->getLinterName())
+          ->setDescription('File needs to be reformatted with scalafmt')
       );
     } else {
       return array();

--- a/src/lint/linter/ArcanistScalafmtLinter.php
+++ b/src/lint/linter/ArcanistScalafmtLinter.php
@@ -26,14 +26,13 @@ final class ArcanistScalafmtLinter extends ArcanistExternalLinter {
   }
 
   public function getInstallInstructions() {
-    return 'Run `brew install olafurpg/scalafmt/scalafmt`';
+    return 'Install using Homebrew: `brew install olafurpg/scalafmt/scalafmt`';
   }
 
   protected function getMandatoryFlags() {
     return array(
       '--config', $this->configPath,
-      '--test',
-      '--files'
+      '-f'
     );
   }
 
@@ -46,14 +45,20 @@ final class ArcanistScalafmtLinter extends ArcanistExternalLinter {
       $stderr
     );
 
-    if ($err != 0) {
+    $originalText = Filesystem::readFile($path);
+    $replacementText = $stdout;
+
+    if ($originalText !== $replacementText) {
       return array(
         id(new ArcanistLintMessage())
-          ->setName($this->getLinterName())
           ->setPath($path)
-          ->setCode($this->getLinterName())
-          ->setSeverity(ArcanistLintSeverity::SEVERITY_ERROR)
-          ->setDescription('Incorrectly formatted file: ' . $path)
+          ->setLine(1)
+          ->setChar(1)
+          ->setSeverity(ArcanistLintSeverity::SEVERITY_AUTOFIX)
+          ->setName($this->getLinterName())
+          ->setDescription('File needs to be reformatted with scalafmt')
+          ->setOriginalText($originalText)
+          ->setReplacementText($replacementText)
       );
     } else {
       return array();

--- a/src/lint/linter/ArcanistScalafmtLinter.php
+++ b/src/lint/linter/ArcanistScalafmtLinter.php
@@ -56,6 +56,7 @@ final class ArcanistScalafmtLinter extends ArcanistExternalLinter {
           ->setChar(1)
           ->setSeverity(ArcanistLintSeverity::SEVERITY_AUTOFIX)
           ->setName($this->getLinterName())
+          ->setDescription('Accept Arcanist\'s autofixes for this file, e.g. `arc lint --apply-patches`')
           ->setOriginalText($originalText)
           ->setReplacementText($replacementText),
         id(new ArcanistLintMessage())


### PR DESCRIPTION
Add a redundant lint error with severity "autofix" so that developers can use `arc lint --apply-patches` to automatically format their code.

I've retained the lint error with severity "error" (even though they're redundant) to ensure formatting is non-optional. Otherwise, if you decline to apply the patches, Arcanist still says linting found no errors, which we don't want.